### PR TITLE
Support connecting via kernel device file

### DIFF
--- a/examples/kernel_print.rs
+++ b/examples/kernel_print.rs
@@ -1,0 +1,33 @@
+use std::error::Error;
+
+use brother_ql::{
+    connection::{KernelConnection, PrinterConnection},
+    media::Media,
+    printjob::PrintJob,
+};
+use tracing_subscriber::{field::MakeExt, EnvFilter};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // This example uses pretty logging
+    tracing_subscriber::fmt()
+        .map_fmt_fields(|f| f.debug_alt())
+        .with_env_filter(EnvFilter::new("debug"))
+        .init();
+
+    // Open kernel connection
+    let mut connection = KernelConnection::open("/dev/usb/lp0")?;
+    // Read status from printer
+    let _status = connection.get_status()?;
+    // Create a print job with more than one page
+    let img = image::open("test.png")?;
+    let job = PrintJob::new(img, Media::C62)?;
+    // These are the defaults for the other options:
+    // .high_dpi(false)
+    // .compressed(false)
+    // .quality_priority(true)
+    // .cut_behavior(CutBehavior::CutEach)?; // default for continuous media
+    // Finally, print
+    connection.print(job)?;
+
+    Ok(())
+}

--- a/examples/kernel_status.rs
+++ b/examples/kernel_status.rs
@@ -1,0 +1,22 @@
+//! Read and display printer status via kernel interface
+
+use std::error::Error;
+
+use brother_ql::connection::KernelConnection;
+use tracing_subscriber::{field::MakeExt, EnvFilter};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // This example uses logging
+    tracing_subscriber::fmt()
+        .map_fmt_fields(|f| f.debug_alt())
+        .with_env_filter(EnvFilter::new("debug"))
+        .init();
+
+    // Open kernel connection
+    let mut connection = KernelConnection::open("/dev/usb/lp0")?;
+    // Read status from printer
+    let status = connection.get_status()?;
+    println!("Model: {:?}", status.model);
+
+    Ok(())
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -3,6 +3,7 @@
 //! This module provides connection abstractions for communicating with Brother QL printers.
 //! Currently supports USB connections, with network connections planned for the future.
 
+mod kernel_connection;
 mod printer_connection;
 mod usb_connection;
 
@@ -11,3 +12,6 @@ pub use printer_connection::PrinterConnection;
 
 // Re-export USB types
 pub use usb_connection::{UsbConnection, UsbConnectionInfo};
+
+// Re-export kernel types
+pub use kernel_connection::KernelConnection;

--- a/src/connection/kernel_connection.rs
+++ b/src/connection/kernel_connection.rs
@@ -1,0 +1,162 @@
+//! Kernel connection support for Brother QL printers
+use std::{
+    fs::{File, OpenOptions},
+    io::{Read, Write},
+    path::Path,
+    time::Duration,
+};
+
+use tracing::{debug, info};
+
+use crate::{
+    commands::{RasterCommand, RasterCommands},
+    error::{KernelError, PrintError, ProtocolError, StatusError},
+    printjob::PrintJob,
+    status::{Phase, StatusInformation, StatusType},
+};
+
+use super::PrinterConnection;
+
+/// Kernel connection to a Brother QL printer
+pub struct KernelConnection {
+    handle: File,
+}
+
+impl KernelConnection {
+    /// Open a kernel connection to a Brother QL printer
+    pub fn open<P>(path: P) -> Result<Self, KernelError>
+    where
+        P: AsRef<Path>,
+    {
+        debug!("Opening kernel connection to the printer...");
+        let handle = OpenOptions::new().read(true).write(true).open(path)?;
+
+        debug!("Successfully opened kernel device!");
+        Ok(Self { handle })
+    }
+
+    /// Write data to the printer
+    fn write(&mut self, data: &[u8]) -> Result<(), KernelError> {
+        let bytes_written = self.handle.write(data)?;
+        if bytes_written != data.len() {
+            return Err(KernelError::IncompleteWrite);
+        }
+        Ok(())
+    }
+
+    fn send_status_request(&mut self) -> Result<(), KernelError> {
+        debug!("Sending status information request to the printer...");
+        let status_request_bytes: Vec<u8> = RasterCommand::StatusInformationRequest.into();
+        self.write(&status_request_bytes)?;
+        Ok(())
+    }
+
+    /// Read status information from the printer
+    pub fn get_status(&mut self) -> Result<StatusInformation, StatusError> {
+        let preamble_bytes = RasterCommands::create_preamble().build();
+        self.write(&preamble_bytes)?;
+        self.send_status_request()?;
+        self.read_status_reply()
+    }
+
+    /// Read status information but without sending init/invalidate bytes
+    fn read_status_reply(&mut self) -> Result<StatusInformation, StatusError> {
+        let mut read_buffer = [0u8; 32];
+        self.read_exact(&mut read_buffer)?;
+        let status = StatusInformation::try_from(&read_buffer[..])?;
+        debug!(?status, "Printer sent status information");
+        Ok(status)
+    }
+
+    /// Read raw data from the printer
+    fn read(&mut self, buffer: &mut [u8]) -> Result<usize, KernelError> {
+        let bytes_read = self.handle.read(buffer)?;
+        Ok(bytes_read)
+    }
+
+    /// Read until the provided buffer is full
+    fn read_exact(&mut self, buffer: &mut [u8]) -> Result<(), StatusError> {
+        // 3000ms / 50ms = 60 retries
+        const MAX_RETRIES: u8 = 60;
+        const RETRY_DELAY: Duration = Duration::from_millis(50);
+
+        let mut total_read = 0;
+        let mut retries = 0;
+
+        while total_read < buffer.len() {
+            match self.read(&mut buffer[total_read..]) {
+                Ok(0) => {
+                    retries += 1;
+                    if retries > MAX_RETRIES {
+                        return Err(StatusError::NoResponse);
+                    }
+                    // No data available yet, wait and retry
+                    std::thread::sleep(RETRY_DELAY);
+                }
+                Ok(n) => {
+                    total_read += n;
+                    retries = 0; // Reset retries on successful read
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate that information reply matches expected state
+    fn validate_status(
+        status: &StatusInformation,
+        expected_type: &StatusType,
+        expected_phase: &Phase,
+    ) -> Result<(), ProtocolError> {
+        // Check if printer has errors first
+        if status.has_errors() {
+            return Err(ProtocolError::PrinterError(status.errors));
+        }
+
+        // Check if status type and phase match expectations
+        if &status.status_type != expected_type || &status.phase != expected_phase {
+            return Err(ProtocolError::UnexpectedStatus {
+                expected_type: expected_type.clone(),
+                expected_phase: expected_phase.clone(),
+                actual_type: status.status_type.clone(),
+                actual_phase: status.phase.clone(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+impl PrinterConnection for KernelConnection {
+    fn print(&mut self, job: PrintJob) -> Result<(), PrintError> {
+        info!(?job, "Starting print job...");
+        let no_pages = job.page_count;
+        let parts = job.into_parts();
+        // Send preamble
+        self.write(&parts.preamble.build())?;
+        // Send status information request and validate printer is ready
+        let status = self.get_status().map_err(PrintError::Status)?;
+        Self::validate_status(&status, &StatusType::StatusRequestReply, &Phase::Receiving)?;
+        for (page_no, page) in parts.page_data.into_iter().enumerate() {
+            debug!(
+                "Sending print data for page {}/{}...",
+                page_no + 1,
+                no_pages
+            );
+            self.write(&page.build())?;
+            // Printer should change phase to "Printing"
+            let status = self.read_status_reply().map_err(PrintError::Status)?;
+            Self::validate_status(&status, &StatusType::PhaseChange, &Phase::Printing)?;
+            // Printer should signal print completion
+            let status = self.read_status_reply().map_err(PrintError::Status)?;
+            Self::validate_status(&status, &StatusType::PrintingCompleted, &Phase::Printing)?;
+            // Printer should change phase to "Receiving" again
+            let status = self.read_status_reply().map_err(PrintError::Status)?;
+            Self::validate_status(&status, &StatusType::PhaseChange, &Phase::Receiving)?;
+            info!("Page {}/{} printed successfully!", page_no + 1, no_pages);
+        }
+        info!("Print job completed successfully!");
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,20 @@ pub enum UsbError {
     Rusb(#[from] rusb::Error),
 }
 
+/// Kernel communication errors
+#[derive(Error, Debug)]
+pub enum KernelError {
+    /// Kernel read/write operation failed
+    #[error("Kernel IO error: {0}")]
+    IOError(#[from] std::io::Error),
+
+    /// Failed to write all data to the kernel device
+    ///
+    /// This should never occur, but if it does, please report it as a GitHub issue
+    #[error("Incomplete kernel write occured! Please report this issue!")]
+    IncompleteWrite,
+}
+
 /// Status parsing errors
 ///
 /// Returned when status bytes from the printer are malformed.
@@ -93,6 +107,10 @@ pub enum StatusError {
     /// USB communication error
     #[error(transparent)]
     Usb(#[from] UsbError),
+
+    /// Kernel communication error
+    #[error(transparent)]
+    Kernel(#[from] KernelError),
 
     /// Printer did not respond after retries
     #[error("Printer did not respond with a status information reply after being queried")]
@@ -135,6 +153,10 @@ pub enum PrintError {
     /// USB communication error
     #[error(transparent)]
     Usb(#[from] UsbError),
+
+    /// Kernel communication error
+    #[error(transparent)]
+    Kernel(#[from] KernelError),
 
     /// Status reading error (communication, timeout, or parsing)
     #[error(transparent)]


### PR DESCRIPTION
This is pretty much based on the USB implementation, I did not try to clean anything up since I have the feeling this would just lead to annoying merge conflicts on your side.

What I noticed is that there's a fair bit of duplicate code between the USB and kernel interfaces, so I think it would make sense to do some refactoring to deduplicate it and only implement open/read/write differently for usb/kernel but reuse all the other code.