### PR TITLE
fix: correct die-cut printable lengths against Brother's QL-800 raster reference

### DIFF
--- a/crates/brother_ql/src/media.rs
+++ b/crates/brother_ql/src/media.rs
@@ -311,7 +311,7 @@ define_media! {
         left_margin: 555,
         supports_color: false,
         length_mm: 87,
-        length_dots: 912,
+        length_dots: 956,
     },
     D23x23 {
         products: ["DK-11221 Square Labels"],
@@ -321,7 +321,7 @@ define_media! {
         left_margin: 442,
         supports_color: false,
         length_mm: 23,
-        length_dots: 236,
+        length_dots: 202,
     },
     D29x42 {
         products: ["DK-11215 Labels (⚠️ no official data)"],
@@ -341,7 +341,7 @@ define_media! {
         left_margin: 408,
         supports_color: false,
         length_mm: 90,
-        length_dots: 944,
+        length_dots: 991,
     },
     D38x90 {
         products: ["DK-11208 Large Address Labels"],
@@ -351,7 +351,7 @@ define_media! {
         left_margin: 295,
         supports_color: false,
         length_mm: 90,
-        length_dots: 944,
+        length_dots: 991,
     },
     D39x48 {
         products: ["DK-11220 Labels (⚠️ no official data)"],
@@ -361,7 +361,7 @@ define_media! {
         left_margin: 289,
         supports_color: false,
         length_mm: 48,
-        length_dots: 512,
+        length_dots: 495,
     },
     D52x29 {
         products: ["DK-11226 Labels (⚠️ no official data)"],
@@ -371,7 +371,7 @@ define_media! {
         left_margin: 142,
         supports_color: false,
         length_mm: 29,
-        length_dots: 318,
+        length_dots: 271,
     },
     D54x29 {
         products: ["DK-3235 Removable"],
@@ -381,7 +381,7 @@ define_media! {
         left_margin: 59,
         supports_color: false,
         length_mm: 29,
-        length_dots: 318,
+        length_dots: 271,
     },
     D60x86 {
         products: ["DK-11234 Name Badge Labels"],
@@ -391,7 +391,7 @@ define_media! {
         left_margin: 24,
         supports_color: false,
         length_mm: 86,
-        length_dots: 902,
+        length_dots: 954,
     },
     D62x29 {
         products: ["DK-11209 Small Address Labels"],
@@ -411,7 +411,7 @@ define_media! {
         left_margin: 12,
         supports_color: false,
         length_mm: 100,
-        length_dots: 1104,
+        length_dots: 1109,
     },
     D12 {
         products: ["DK-11219 Round Labels"],
@@ -441,6 +441,6 @@ define_media! {
         left_margin: 51,
         supports_color: false,
         length_mm: 58,
-        length_dots: 630,
+        length_dots: 618,
     },
 }

--- a/crates/brother_ql/src/media.rs
+++ b/crates/brother_ql/src/media.rs
@@ -401,7 +401,7 @@ define_media! {
         left_margin: 12,
         supports_color: false,
         length_mm: 29,
-        length_dots: 318,
+        length_dots: 271,
     },
     D62x100 {
         products: ["DK-11202 Shipping Labels"],


### PR DESCRIPTION
## Hello again! :)

For 62x29 (DK-11209) the declared 318 is 47 dots longer than the 271 the printer inks. The overrun crosses the die-cut boundary, so content lands on the *next* label and each job advances more media than one label.

Brother's [QL-800/810W/820NWB Raster Command Reference](https://download.brother.com/welcome/docp100278/cv_ql800_eng_raster_101.pdf)

## Verified on hardware

QL-800 with DK-11209, same artwork both ways:

| raster | result |
|---|---|
| 696 x 271 | registers on one label, one label of media consumed |
| 696 x 318 | content bleeds onto the following label, extra media fed |

## The commits

1. **62x29 only** — the case reproduced and fixed on hardware.
2. **The remaining die-cut media** — every other entry whose length disagrees with the same spec table, derived rather than hardware-tested, so it can be dropped or taken separately:

   | media | before | after |
   |---|---|---|
   | 17x87 | 912 | 956 |
   | 23x23 | 236 | 202 |
   | 29x90 | 944 | 991 |
   | 38x90 | 944 | 991 |
   | 39x48 | 512 | 495 |
   | 52x29 | 318 | 271 |
   | 54x29 | 318 | 271 |
   | 60x86 | 902 | 954 |
   | 62x100 | 1104 | 1109 |
   | 58 round | 630 | 618 |

`17x54`, `12 round` and `24 round` already match the spec and are untouched. `29x42` is not in the QL-800 reference, so I left it alone.

Widths are all correct already; this is only the length column. Note `23x23` also had its width right (236) but its length copied from `24 round` — the reference gives 236 x 202.